### PR TITLE
fix / add badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Eventsimple
-[![Github Actions Badge](https://github.com/wealthsimple/eventsimple/actions/workflows/main.yml/badge.svg)](https://github.com/wealthsimple/eventsimple/actions)
+[![Github Actions](https://github.com/wealthsimple/eventsimple/actions/workflows/default.yml/badge.svg)](https://github.com/wealthsimple/eventsimple/actions/workflows/default.yml) [![Gem Version](https://badge.fury.io/rb/eventsimple.svg)](https://rubygems.org/gems/eventsimple)
 
 ## What
 Eventsimple implements a simple deterministic event driven system using ActiveRecord and Sidekiq.

--- a/spec/eventsimple_spec.rb
+++ b/spec/eventsimple_spec.rb
@@ -35,20 +35,20 @@ RSpec.describe 'a published gem' do # rubocop:disable RSpec/DescribeClass
     base = git.merge_base(main_branch, 'HEAD').first&.sha
     base ||= main_branch
     git.diff(base, 'HEAD').any? { |diff|
-      not_gemfile?(diff) && not_lockfile?(diff) && not_ci_file?(diff) && not_docs?(diff)
+      not_gemfile_or_lockfile?(diff) && not_ci_file?(diff) && not_docs?(diff) && not_spec?(diff)
     }
   end
 
-  def not_lockfile?(diff)
-    diff.path != 'Gemfile.lock'
-  end
-
-  def not_gemfile?(diff)
-    diff.path != 'Gemfile'
+  def not_gemfile_or_lockfile?(diff)
+    diff.path != 'Gemfile' && diff.path != 'Gemfile.lock'
   end
 
   def not_docs?(diff)
     !diff.path.end_with?('.md')
+  end
+
+  def not_spec?(diff)
+    !diff.path.start_with?('spec/')
   end
 
   def not_ci_file?(diff)

--- a/spec/eventsimple_spec.rb
+++ b/spec/eventsimple_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe 'a published gem' do # rubocop:disable RSpec/DescribeClass
     base = git.merge_base(main_branch, 'HEAD').first&.sha
     base ||= main_branch
     git.diff(base, 'HEAD').any? { |diff|
-      not_gemfile_or_lockfile?(diff) && not_ci_file?(diff) && not_docs?(diff) && not_spec?(diff)
+      not_gemfile?(diff) && not_ci_file?(diff) && not_docs?(diff) && not_spec?(diff)
     }
   end
 
-  def not_gemfile_or_lockfile?(diff)
-    diff.path != 'Gemfile' && diff.path != 'Gemfile.lock'
+  def not_gemfile?(diff)
+    ['Gemfile', 'Gemfile.lock'].exclude?(diff.path)
   end
 
   def not_docs?(diff)

--- a/spec/eventsimple_spec.rb
+++ b/spec/eventsimple_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'a published gem' do # rubocop:disable RSpec/DescribeClass
     base = git.merge_base(main_branch, 'HEAD').first&.sha
     base ||= main_branch
     git.diff(base, 'HEAD').any? { |diff|
-      not_gemfile?(diff) && not_lockfile?(diff) && not_ci_file?(diff)
+      not_gemfile?(diff) && not_lockfile?(diff) && not_ci_file?(diff) && not_docs?(diff)
     }
   end
 
@@ -45,6 +45,10 @@ RSpec.describe 'a published gem' do # rubocop:disable RSpec/DescribeClass
 
   def not_gemfile?(diff)
     diff.path != 'Gemfile'
+  end
+
+  def not_docs?(diff)
+    !diff.path.end_with?('.md')
   end
 
   def not_ci_file?(diff)


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
- fix broken github actions badge
- add rubygems badge which shows the current (latest) version'
- update spec to not require version bump for markdown-only changes or spec-only changes
