### PR TITLE
active_job_parent_klass config is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.1.1 - 2023-06-19
+### Changed
+- Remove active_job_parent_klass config introduced in 1.1.0. There isn't a usecase for it yet,
+  and it was causing loading issues.
+
 ## 1.1.0 - 2023-06-11
 ### Changed
 - Reactors now use ActiveJob instead of Sidekiq directly. This allows for more

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventsimple (1.1.0)
+    eventsimple (1.1.1)
       dry-struct (~> 1.6)
       dry-types (~> 1.7)
       pg (~> 1.4)
@@ -159,7 +159,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.18.0)
     nenv (0.3.0)
-    net-imap (0.3.4)
+    net-imap (0.3.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -284,7 +284,7 @@ GEM
       rubocop (>= 0.53.0)
     ruby-progressbar (1.13.0)
     shellany (0.0.1)
-    sidekiq (7.1.1)
+    sidekiq (7.1.2)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)

--- a/README.md
+++ b/README.md
@@ -74,11 +74,6 @@ Setup an initializer in `config/initializers/eventsimple.rb`:
     # Defaults to `Eventsimple::Metadata`
     config.metadata_klass = 'Eventsimple::Metadata'
 
-    # Optional: Reactors inherit from an ActiveJob base class.
-    # Set the parent class for reactors.
-    # Defaults to ActiveJob::Base.
-    config.active_job_parent_klass = 'ApplicationJob'
-
     # Optional: When using an ActiveJob adapter that writes to a different data store like redis,
     # it is possible that the reactor is executed before the transaction persisting the event is committed. This can result in noisy errors when using processors like Sidekiq.
     # Enable this option to retry the reactor inline if the event is not found.

--- a/lib/eventsimple.rb
+++ b/lib/eventsimple.rb
@@ -20,6 +20,7 @@ require 'eventsimple/metadata_type'
 require 'eventsimple/metadata'
 require 'eventsimple/dispatcher'
 require 'eventsimple/event_dispatcher'
+require 'eventsimple/reactor'
 require 'eventsimple/reactor_worker'
 require 'eventsimple/invalid_transition'
 

--- a/lib/eventsimple/configuration.rb
+++ b/lib/eventsimple/configuration.rb
@@ -4,7 +4,6 @@ module Eventsimple
   class Configuration
     attr_reader :max_concurrency_retries
     attr_writer :metadata_klass
-    attr_writer :active_job_parent_klass
     attr_accessor :retry_reactor_on_record_not_found
 
     attr_accessor :ui_visible_models
@@ -13,7 +12,6 @@ module Eventsimple
       @dispatchers = []
       @max_concurrency_retries = 2
       @metadata_klass = 'Eventsimple::Metadata'
-      @active_job_parent_klass = 'ActiveJob::Base'
       @retry_reactor_on_record_not_found = false
 
       @ui_visible_models = [] # internal use only
@@ -34,17 +32,12 @@ module Eventsimple
     end
 
     # rubocop:disable Naming/MemoizedInstanceVariableName
-
     def dispatchers
       @dispatchers_klass_consts ||= @dispatchers.map(&:constantize)
     end
 
     def metadata_klass
       @metadata_klass_const ||= @metadata_klass.constantize
-    end
-
-    def active_job_parent_klass
-      @active_job_parent_klass_const ||= @active_job_parent_klass.constantize
     end
     # rubocop:enable Naming/MemoizedInstanceVariableName
   end

--- a/lib/eventsimple/reactor.rb
+++ b/lib/eventsimple/reactor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Eventsimple
-  class Reactor < Eventsimple.configuration.active_job_parent_klass
+  class Reactor < ActiveJob::Base # rubocop:disable Rails/ApplicationJob
     queue_as :eventsimple
 
     def perform(event)

--- a/lib/eventsimple/version.rb
+++ b/lib/eventsimple/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Eventsimple
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/spec/dummy/app/jobs/application_job.rb
+++ b/spec/dummy/app/jobs/application_job.rb
@@ -1,2 +1,0 @@
-class ApplicationJob < ActiveJob::Base
-end

--- a/spec/dummy/config/initializers/eventsimple.rb
+++ b/spec/dummy/config/initializers/eventsimple.rb
@@ -3,5 +3,4 @@ Eventsimple.configure do |config|
   config.dispatchers = %w[
     UserComponent::Dispatcher
   ]
-  config.active_job_parent_klass = 'ApplicationJob'
 end


### PR DESCRIPTION
Fixing an issue where the parent app is unable to find the reactor class.
We've removed the active_job_parent_klass config option and can reintroduce it in the future when the use case arises.