### PR TITLE
allow events to override timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.2.1 - 2023-11-18
+### Changed
+- Allow timestamp data in events to override default timestamps update.
+- This allows us to create temporal events for example in the case of snapshots.
+
 ## 1.2.0 - 2023-09-26
 ### Changed
 - Fix issue where the reactor worker might not work correctly for models not inheriting from ApplicationRecord.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventsimple (1.2.0)
+    eventsimple (1.2.1)
       dry-struct (~> 1.6)
       dry-types (~> 1.7)
       pg (~> 1.4)
@@ -89,7 +89,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
-    date (3.3.3)
+    date (3.3.4)
     diff-lcs (1.5.0)
     dry-core (1.0.1)
       concurrent-ruby (~> 1.0)
@@ -158,12 +158,12 @@ GEM
     mini_mime (1.1.5)
     minitest (5.20.0)
     nenv (0.3.0)
-    net-imap (0.3.7)
+    net-imap (0.4.5)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.1)
+    net-protocol (0.2.2)
       timeout
     net-smtp (0.4.0)
       net-protocol
@@ -300,7 +300,7 @@ GEM
       lint_roller (~> 1.0)
       rubocop-rails (~> 2.20.2)
     thor (1.2.2)
-    timeout (0.4.0)
+    timeout (0.4.1)
     treetop (1.6.12)
       polyglot (~> 0.3)
     tzinfo (2.0.6)

--- a/README.md
+++ b/README.md
@@ -176,8 +176,6 @@ module UserComponent
       def apply(user)
         user.canonical_id = data.canonical_id
         user.email = data.email
-
-        user
       end
     end
   end

--- a/lib/eventsimple/entity.rb
+++ b/lib/eventsimple/entity.rb
@@ -35,8 +35,8 @@ module Eventsimple
         assign_attributes(self.class.column_defaults.except(*ignore_props))
 
         event_history.each do |event|
-          event.apply(self)
           event.apply_timestamps(self)
+          event.apply(self)
         end
 
         self

--- a/lib/eventsimple/event.rb
+++ b/lib/eventsimple/event.rb
@@ -86,8 +86,8 @@ module Eventsimple
 
       # Apply the transformation to the aggregate and save it.
       def apply_and_persist
-        apply(aggregate)
         apply_timestamps(aggregate)
+        apply(aggregate)
 
         # Persist!
         aggregate.save!

--- a/lib/eventsimple/support/spec_helpers.rb
+++ b/lib/eventsimple/support/spec_helpers.rb
@@ -45,3 +45,5 @@ RSpec.shared_examples 'an event in invalid state that is rescued' do
     end
   end
 end
+
+RSpec::Matchers.define_negated_matcher(:not_change, :change)

--- a/lib/eventsimple/version.rb
+++ b/lib/eventsimple/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Eventsimple
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/spec/dummy/app/components/user_component/events/created.rb
+++ b/spec/dummy/app/components/user_component/events/created.rb
@@ -19,7 +19,6 @@ module UserComponent
         user.canonical_id = data.canonical_id
         user.username = data.username
         user.email = data.email
-        user
       end
     end
   end

--- a/spec/dummy/app/components/user_component/events/deleted.rb
+++ b/spec/dummy/app/components/user_component/events/deleted.rb
@@ -12,8 +12,6 @@ module UserComponent
 
         user.created_at ||= created_at
         user.updated_at = created_at
-
-        user
       end
     end
   end

--- a/spec/dummy/app/components/user_component/events/override_timestamp.rb
+++ b/spec/dummy/app/components/user_component/events/override_timestamp.rb
@@ -2,23 +2,19 @@
 
 module UserComponent
   module Events
-    class RescuedInvalidTransition < UserEvent
-      rescue_invalid_transition
-
+    class OverrideTimestamp < UserEvent
       attribute :data, Eventsimple::DataType.new(self)
 
       class Message < Eventsimple::Message
         attribute :canonical_id, DryTypes::Strict::String
-      end
-
-      def can_apply?(user)
-        user.new_record?
+        attribute :created_at, DryTypes::JSON::Time
+        attribute :updated_at, DryTypes::JSON::Time
       end
 
       def apply(user)
         user.canonical_id = data.canonical_id
-        user.username = 'test'
-        user.email = 'test@example.com'
+        user.created_at = data.created_at
+        user.updated_at = data.updated_at
       end
     end
   end

--- a/spec/dummy/app/components/user_component/events/rescued_invalid_transition_with_reraise.rb
+++ b/spec/dummy/app/components/user_component/events/rescued_invalid_transition_with_reraise.rb
@@ -21,7 +21,6 @@ module UserComponent
         user.canonical_id = data.canonical_id
         user.username = 'test'
         user.email = 'test@example.com'
-        user
       end
     end
   end

--- a/spec/dummy/app/components/user_component/events/updated.rb
+++ b/spec/dummy/app/components/user_component/events/updated.rb
@@ -15,7 +15,6 @@ module UserComponent
 
       def apply(user)
         user.email = data.email
-        user
       end
     end
   end

--- a/spec/dummy/db/migrate/20220917150826_create_users.rb
+++ b/spec/dummy/db/migrate/20220917150826_create_users.rb
@@ -3,7 +3,7 @@ class CreateUsers < ActiveRecord::Migration[7.0]
     create_table :users do |t|
       t.string :canonical_id, null: false
 
-      t.string :username, null: false
+      t.string :username
       t.string :email
 
       t.integer :lock_version

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_17_150839) do
 
   create_table "users", force: :cascade do |t|
     t.string "canonical_id", null: false
-    t.string "username", null: false
+    t.string "username"
     t.string "email"
     t.integer "lock_version"
     t.datetime "deleted_at"

--- a/spec/dummy/spec/components/user_component/events/override_timestamp_spec.rb
+++ b/spec/dummy/spec/components/user_component/events/override_timestamp_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe UserComponent::Events::OverrideTimestamp do
+  describe '#create' do
+    subject(:create_event) { event.save }
+
+    let(:canonical_id) { SecureRandom.uuid }
+
+    let(:user) { User.new }
+    let(:event) do
+      described_class.new(
+        user: user,
+        data: {
+          canonical_id: canonical_id,
+          created_at: Time.new(2023, 1, 1),
+          updated_at: Time.new(2023, 1, 1),
+        },
+      )
+    end
+
+    it 'updates the user properties' do
+      create_event
+
+      expect(user.canonical_id).to eq(event.data.canonical_id)
+      expect(user.created_at).to eq(event.data.created_at)
+      expect(user.updated_at).to eq(event.data.updated_at)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,6 @@ RSpec.configure do |config|
   ENV['RAILS_ROOT'] ||= "#{File.dirname(__FILE__)}../../../spec/dummy"
 
   require 'rspec/rails'
-  RSpec::Matchers.define_negated_matcher(:not_change, :change)
 
   ActiveRecord::Migration.maintain_test_schema!
 


### PR DESCRIPTION
Eventsimple will automatically set timestamps based on event#created_at.
In cases where we are adding eventsimple to existing models, we may need to create a historical snapshot, to set the initial state from the point eventsimple is introduced.

Allow events to override the timestamps by calling the apply function _after_ timestamps are updated.
