### PR TITLE
Support nil metadata properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.3.2 - 2024-02-29
+### Changed
+- `Eventsimple::Metadata` may now store a `nil` value for actor_id and reason.
+
 ## 1.3.1 - 2024-01-19
 ### Changed
 - Restore readonly status to the original status after enable_writes! block.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventsimple (1.3.1)
+    eventsimple (1.3.2)
       dry-struct (~> 1.6)
       dry-types (~> 1.7)
       pg (~> 1.4)

--- a/lib/eventsimple/metadata.rb
+++ b/lib/eventsimple/metadata.rb
@@ -5,7 +5,7 @@ module Eventsimple
   class Metadata < Eventsimple::Message
     schema schema.strict
 
-    attribute? :actor_id, DryTypes::Strict::String
-    attribute? :reason, DryTypes::Strict::String
+    attribute? :actor_id, DryTypes::Strict::String.optional
+    attribute? :reason, DryTypes::Strict::String.optional
   end
 end

--- a/lib/eventsimple/version.rb
+++ b/lib/eventsimple/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Eventsimple
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end

--- a/spec/lib/eventsimple/metadata_spec.rb
+++ b/spec/lib/eventsimple/metadata_spec.rb
@@ -12,9 +12,19 @@ RSpec.describe Eventsimple::Metadata do
     expect(result.actor_id).to eq('id')
   end
 
+  it 'supports an actor_id as nil' do
+    result = described_class.new(actor_id: nil)
+    expect(result.actor_id).to eq(nil)
+  end
+
   it 'supports a reason as a string' do
     result = described_class.new(reason: 'the reason')
     expect(result.reason).to eq('the reason')
+  end
+
+  it 'supports a reason as nil' do
+    result = described_class.new(reason: nil)
+    expect(result.reason).to eq(nil)
   end
 
   it 'raises error on unexpected keys' do


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
Consider the following example.
```ruby
# /api/accounts_controller.rb

def delete
  account = Account.find_by(canonical_id: params[:id])
  Events::Deleted.create!(account: account, metadata: { actor_id: current_actor_id })
end
```
But imagine that the caller is an internal microservice, with no user associated with the request (so `current_actor_id` is nil).
This currently raises the following error.

`#<Dry::Struct::Error: [Eventsimple::Metadata.new] nil (NilClass) has invalid type for :actor_id violates constraints (type?(String, nil) failed)>`

I would expect the metadata to accept a nil actor_id since the attribute key is marked as optional.
https://github.com/wealthsimple/eventsimple/blob/133eb8c1a02cf120bec5b056c0a7fb3ff3ff1d8c/lib/eventsimple/metadata.rb#L8-L9

#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Added support for nil metadata properties

Note: lint step is failing due to security vulnerability in dependencies. Will fix that separately.