### PR TITLE
Create an index on created_at for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.5.2 - 2024-05-22
+### Changed
+- Add created_at index in events migration generation
+
 ## 1.5.1 - 2024-05-13
 ### Changed
 - Fix bug where outbox concurrency was not being configured correctly.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventsimple (1.5.1)
+    eventsimple (1.5.2)
       concurrent-ruby (>= 1.2.3)
       dry-struct (~> 1.6)
       dry-types (~> 1.7)

--- a/lib/eventsimple/generators/templates/create_events.erb
+++ b/lib/eventsimple/generators/templates/create_events.erb
@@ -13,6 +13,7 @@ class Create<%= model_name.camelize %>Events < ActiveRecord::Migration[7.0]
       t.timestamps
 
       t.index :idempotency_key, unique: true
+      t.index :created_at
     end
 
     # Enables optimistic locking on the evented table

--- a/lib/eventsimple/version.rb
+++ b/lib/eventsimple/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Eventsimple
-  VERSION = '1.5.1'
+  VERSION = '1.5.2'
 end

--- a/spec/dummy/db/migrate/20220917150839_create_user_events.rb
+++ b/spec/dummy/db/migrate/20220917150839_create_user_events.rb
@@ -10,6 +10,7 @@ class CreateUserEvents < ActiveRecord::Migration[7.0]
       t.timestamps
 
       t.index :idempotency_key, unique: true
+      t.index :created_at
 
       # temporary to enable backfill
       t.integer :eventide_position_id

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_19_175459) do
     t.datetime "updated_at", null: false
     t.integer "eventide_position_id"
     t.index ["aggregate_id"], name: "index_user_events_on_aggregate_id"
+    t.index ["created_at"], name: "index_user_events_on_created_at"
     t.index ["eventide_position_id"], name: "index_user_events_on_eventide_position_id", unique: true
     t.index ["idempotency_key"], name: "index_user_events_on_idempotency_key", unique: true
   end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
Adding an index for created_at for events tables because we always order by created_at in the UI and eventually the size of the table causes timeouts


#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Include an index for created_at by default in the template for creating the events table

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
