### PR TITLE
make application record configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.3.3 - 2024-04-02
+### Changed
+- add `parent_record` configuration so it can be easily overwritten
+
 ## 1.3.2 - 2024-03-01
 ### Changed
 - Updated dependencies to fix a security vulnerability

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventsimple (1.3.2)
+    eventsimple (1.3.3)
       dry-struct (~> 1.6)
       dry-types (~> 1.7)
       pg (~> 1.4)
@@ -358,6 +358,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/eventsimple/configuration.rb
+++ b/lib/eventsimple/configuration.rb
@@ -4,6 +4,7 @@ module Eventsimple
   class Configuration
     attr_reader :max_concurrency_retries
     attr_writer :metadata_klass
+    attr_writer :parent_record_klass
     attr_accessor :retry_reactor_on_record_not_found
 
     attr_accessor :ui_visible_models
@@ -12,6 +13,7 @@ module Eventsimple
       @dispatchers = []
       @max_concurrency_retries = 2
       @metadata_klass = 'Eventsimple::Metadata'
+      @parent_record_klass = 'ApplicationRecord'
       @retry_reactor_on_record_not_found = false
 
       @ui_visible_models = [] # internal use only
@@ -38,6 +40,10 @@ module Eventsimple
 
     def metadata_klass
       @metadata_klass_const ||= @metadata_klass.constantize
+    end
+
+    def parent_record_klass
+      @parent_record_const ||= @parent_record_klass.constantize
     end
     # rubocop:enable Naming/MemoizedInstanceVariableName
   end

--- a/lib/eventsimple/outbox/models/cursor.rb
+++ b/lib/eventsimple/outbox/models/cursor.rb
@@ -2,7 +2,7 @@
 
 module Eventsimple
   module Outbox
-    class Cursor < ApplicationRecord
+    class Cursor < Eventsimple.configuration.parent_record_klass
       self.table_name = 'eventsimple_outbox_cursors'
 
       def self.fetch(event_klass, group_number)

--- a/lib/eventsimple/version.rb
+++ b/lib/eventsimple/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Eventsimple
-  VERSION = '1.3.2'
+  VERSION = '1.3.3'
 end

--- a/spec/dummy/app/models/common/account_service_application_record.rb
+++ b/spec/dummy/app/models/common/account_service_application_record.rb
@@ -1,0 +1,5 @@
+module Common
+  class AccountServiceApplicationRecord < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
+    self.abstract_class = true
+  end
+end

--- a/spec/dummy/app/models/common/account_service_application_record.rb
+++ b/spec/dummy/app/models/common/account_service_application_record.rb
@@ -1,5 +1,0 @@
-module Common
-  class AccountServiceApplicationRecord < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
-    self.abstract_class = true
-  end
-end

--- a/spec/dummy/app/models/common/secondary_application_record.rb
+++ b/spec/dummy/app/models/common/secondary_application_record.rb
@@ -1,0 +1,5 @@
+module Common
+  class SecondaryApplicationRecord < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
+    self.abstract_class = true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_17_150839) do
+ActiveRecord::Schema[7.1].define(version: 2022_09_17_150839) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,6 +36,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_17_150839) do
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["canonical_id"], name: "index_users_on_canonical_id", unique: true
   end
 
 end

--- a/spec/lib/eventsimple/configuration_spec.rb
+++ b/spec/lib/eventsimple/configuration_spec.rb
@@ -42,4 +42,20 @@ RSpec.describe Eventsimple::Configuration do
       expect { config.metadata_klass }.to raise_error(NameError)
     end
   end
+
+  describe '#parent_record_klass' do
+    it 'defaults to ApplicationRecord' do
+      expect(config.parent_record_klass).to eq(ApplicationRecord)
+    end
+
+    it "raises when class name cannot be constantized" do
+      config.parent_record_klass = "Eventsimple::OtherClass"
+      expect { config.parent_record_klass }.to raise_error(NameError)
+    end
+
+    it "sets to expected name when changed" do
+      config.parent_record_klass = "Common::AccountServiceApplicationRecord"
+      expect(config.parent_record_klass).to eq(Common::AccountServiceApplicationRecord)
+    end
+  end
 end

--- a/spec/lib/eventsimple/configuration_spec.rb
+++ b/spec/lib/eventsimple/configuration_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Eventsimple::Configuration do
     end
 
     it "sets to expected name when changed" do
-      config.parent_record_klass = "Common::AccountServiceApplicationRecord"
-      expect(config.parent_record_klass).to eq(Common::AccountServiceApplicationRecord)
+      config.parent_record_klass = "Common::SecondaryApplicationRecord"
+      expect(config.parent_record_klass).to eq(Common::SecondaryApplicationRecord)
     end
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
When using this in wealthsimple we need to be able to have the Cursor inherit from a specific ApplicationRecord (due to multiple DBs). Making this configurable 


#### What changed <!-- Summary of changes when modifying hundreds of lines -->
- Add new `parent_record` config 


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
