### PR TITLE
eventsimple outbox processor is instantiated once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.4.0 - 2024-04-02
+### Changed
+- Production ready release of the outbox consumer
+- Multiple consumers on an event stream are supported
+- The outbox processor is instantiated once and takes the event as an argument.
+- Added proper SIGTERM event handling and fixed shutdown behaviour.
+
 ## 1.3.3 - 2024-04-02
 ### Changed
 - add `parent_record` configuration so it can be easily overwritten

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,9 @@
 
 source 'https://rubygems.org'
 
+group :test do
+  gem 'factory_bot_rails'
+end
+
 # Specify your gem's dependencies in eventsimple.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 PATH
   remote: .
   specs:
-    eventsimple (1.3.3)
+    eventsimple (1.4.0)
       dry-struct (~> 1.6)
       dry-types (~> 1.7)
       pg (~> 1.4)
       rails (~> 7.0)
       retriable (~> 3.1)
+      with_advisory_lock (>= 5.1)
 
 GEM
   remote: https://rubygems.org/
@@ -176,7 +177,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.3)
+    marcel (1.0.4)
     method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.22.2)
@@ -189,7 +190,7 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0.1)
+    net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.0)
     nokogiri (1.16.2-arm64-darwin)
@@ -205,7 +206,7 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
-    pg (1.5.5)
+    pg (1.5.6)
     polyglot (0.3.5)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -348,6 +349,9 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    with_advisory_lock (5.1.0)
+      activerecord (>= 6.1)
+      zeitwerk (>= 2.6)
     ws-style (7.4.3)
       rubocop-rspec (>= 2.2.0)
       rubocop-vendor (>= 0.11)

--- a/eventsimple.gemspec
+++ b/eventsimple.gemspec
@@ -28,9 +28,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'pg', '~> 1.4'
   spec.add_runtime_dependency 'rails', '~> 7.0'
   spec.add_runtime_dependency 'retriable', '~> 3.1'
+  spec.add_runtime_dependency 'with_advisory_lock', '>= 5.1'
 
   spec.add_development_dependency 'bundle-audit'
-  spec.add_development_dependency 'factory_bot_rails'
   spec.add_development_dependency 'fuubar'
   spec.add_development_dependency 'git'
   spec.add_development_dependency 'guard-rspec'

--- a/lib/eventsimple/event.rb
+++ b/lib/eventsimple/event.rb
@@ -14,8 +14,8 @@ module Eventsimple
       class_attribute :_aggregate_id
       self._aggregate_id = aggregate_id
 
-      class_attribute :_outbox_mode
-      class_attribute :_outbox_concurrency
+      class_attribute :_outbox_enabled
+      class_attribute :_consumer_group_size
 
       class_attribute :_on_invalid_transition
       self._on_invalid_transition = ->(error) { raise error }
@@ -161,7 +161,7 @@ module Eventsimple
       end
 
       def with_locks(&block)
-        if _outbox_mode
+        if _outbox_enabled
           base_class.with_advisory_lock(base_class.name, { transaction: true }, &block)
         else
           yield

--- a/lib/eventsimple/outbox/models/cursor.rb
+++ b/lib/eventsimple/outbox/models/cursor.rb
@@ -5,19 +5,19 @@ module Eventsimple
     class Cursor < Eventsimple.configuration.parent_record_klass
       self.table_name = 'eventsimple_outbox_cursors'
 
-      def self.fetch(event_klass, group_number)
-        existing = find_by(event_klass: event_klass.to_s, group_number: group_number)
+      def self.fetch(identifier, group_number: 0)
+        existing = find_by(identifier: identifier.to_s, group_number: group_number)
         existing ? existing.cursor : 0
       end
 
-      def self.set(event_klass, group_number, cursor)
+      def self.set(identifier, cursor, group_number: 0)
         upsert(
           {
-            event_klass: event_klass.to_s,
+            identifier: identifier.to_s,
             group_number: group_number,
             cursor: cursor,
           },
-          unique_by: [:event_klass, :group_number],
+          unique_by: [:identifier, :group_number],
         )
       end
     end

--- a/lib/eventsimple/version.rb
+++ b/lib/eventsimple/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Eventsimple
-  VERSION = '1.3.3'
+  VERSION = '1.4.0'
 end

--- a/spec/dummy/app/components/user_component/consumer.rb
+++ b/spec/dummy/app/components/user_component/consumer.rb
@@ -1,0 +1,11 @@
+require 'eventsimple/outbox/consumer'
+
+module UserComponent
+  class Consumer
+    extend Eventsimple::Outbox::Consumer
+
+    identifier 'UserComponent::Consumer'
+    consumes_event UserEvent
+    processor EventProcessor
+  end
+end

--- a/spec/dummy/app/components/user_component/event_processor.rb
+++ b/spec/dummy/app/components/user_component/event_processor.rb
@@ -1,0 +1,7 @@
+module UserComponent
+  class EventProcessor
+    def call(event)
+      # no-op
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20240419175459_create_eventsimple_outbox_cursor.rb
+++ b/spec/dummy/db/migrate/20240419175459_create_eventsimple_outbox_cursor.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateEventsimpleOutboxCursor < ActiveRecord::Migration[7.1]
+  def change
+    create_table :eventsimple_outbox_cursors do |t|
+      t.string :identifier, null: false
+      t.integer :group_number, null: false
+      t.bigint :cursor, null: false
+
+      t.index [:identifier, :group_number], unique: true,
+        name: 'index_eventsimple_outbox_cursors_event_klass_group_number'
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,9 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2022_09_17_150839) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_19_175459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "eventsimple_outbox_cursors", force: :cascade do |t|
+    t.string "identifier", null: false
+    t.integer "group_number", null: false
+    t.bigint "cursor", null: false
+    t.index ["identifier", "group_number"], name: "idx_on_identifier_group_number_1aba2c6d46", unique: true
+  end
 
   create_table "user_events", force: :cascade do |t|
     t.string "aggregate_id", null: false

--- a/spec/dummy/spec/components/user_component/consumer_spec.rb
+++ b/spec/dummy/spec/components/user_component/consumer_spec.rb
@@ -1,0 +1,78 @@
+RSpec.describe UserComponent::Consumer do
+  subject(:run_consumer) { described_class.run_consumer(group_number: 0) }
+
+  before do
+    allow(described_class).to receive(:sleep) do
+      described_class.stop_consumer = true
+    end
+  end
+
+  after do
+    described_class.stop_consumer = false
+  end
+
+  it 'has an identifier' do
+    expect(described_class._identifier).to eq('UserComponent::Consumer')
+  end
+
+  it 'consumes an event' do
+    expect(described_class._event_klass).to eq(UserEvent)
+  end
+
+  it 'has a processor' do
+    expect(described_class._processor_klass).to eq(UserComponent::EventProcessor)
+  end
+
+  describe '.run_consumer' do
+    it 'records the last processed event position' do
+      event = create(:user_event)
+
+      cursor = Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer', group_number: 0)
+      expect(cursor).to be(0)
+
+      expect(described_class._processor).to receive(:call).once
+
+      run_consumer
+
+      cursor = Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer', group_number: 0)
+      expect(cursor).to eq(event.id)
+    end
+
+    context 'when consumer is stopped inside batch' do
+      let(:user) { create(:user) }
+      let!(:events) { create_list(:user_event, 1100, user: user) }
+
+      it 'breaks correctly and sets the cursor to the last processed event position' do
+        allow(described_class._processor).to receive(:call) do |e|
+          expect(e.id).to be_in(events[0..1].map(&:id))
+
+          # stop consumer after the second event in the batch is processed
+          if e.id == events[1].id
+            described_class.stop_consumer = true
+          end
+        end
+
+        run_consumer
+
+        expect(described_class._processor).to have_received(:call).exactly(2).times
+        expect(Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer')).to eq(events[1].id)
+      end
+    end
+
+    context 'with an existing cursor' do
+      let!(:events) { create_list(:user_event, 5) }
+
+      before do
+        Eventsimple::Outbox::Cursor.set('UserComponent::Consumer', events[2].id)
+        allow(described_class._processor).to receive(:call)
+      end
+
+      it 'starts after the last processed event position' do
+        run_consumer
+
+        expect(described_class._processor).to have_received(:call).twice
+        expect(Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer')).to eq(events[4].id)
+      end
+    end
+  end
+end

--- a/spec/dummy/spec/factories/user_event.rb
+++ b/spec/dummy/spec/factories/user_event.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user_event do
+    user
+    type { 'UserComponent::Events::Created' }
+    data {
+      {
+        canonical_id: SecureRandom.uuid,
+        username: 'test-user',
+        email: 'test@example.com',
+      }
+    }
+  end
+end

--- a/spec/lib/eventsimple/event_spec.rb
+++ b/spec/lib/eventsimple/event_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Eventsimple::Event do
     end
 
     context 'when entity is stale' do
+      # disable transactional tests so we can test the retry logic
+      def self.uses_transaction?(_method) = true
+      after { UserEvent.delete_all }
+
       it 'retries and successfully writes the event' do
         stale_user = User.find_by(canonical_id: user_canonical_id)
 
@@ -48,7 +52,7 @@ RSpec.describe Eventsimple::Event do
 
     context 'when an event class no longer exists' do
       it 'uses a no-op deleted class' do
-        UserEvent.insert({ type: 'NonExistentEvent', aggregate_id: user_canonical_id })
+        UserEvent.create!(type: 'NonExistentEvent', aggregate_id: user_canonical_id)
 
         event = UserEvent.last
         expect(event).to be_a(UserEvent::Deleted__NonExistentEvent)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
+ENV['RAILS_ENV'] ||= 'test'
+
+require File.expand_path('../spec/dummy/config/environment.rb', __dir__)
+ENV['RAILS_ROOT'] ||= "#{File.dirname(__FILE__)}../../../spec/dummy"
+
+require 'pry'
 require 'eventsimple'
 require 'eventsimple/support/spec_helpers'
-
 require 'retriable'
+require 'rspec/rails'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -18,6 +24,7 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.disable_monkey_patching!
+  config.use_transactional_fixtures = true
 
   if config.files_to_run.one?
     config.default_formatter = "doc"
@@ -26,11 +33,6 @@ RSpec.configure do |config|
   config.order = :random
 
   Kernel.srand config.seed
-
-  require File.expand_path('../spec/dummy/config/environment.rb', __dir__)
-  ENV['RAILS_ROOT'] ||= "#{File.dirname(__FILE__)}../../../spec/dummy"
-
-  require 'rspec/rails'
 
   ActiveRecord::Migration.maintain_test_schema!
 


### PR DESCRIPTION
This PR, makes breaking changes to the outbox implementation.
However as the original outbox implementation was a POC that is not currently used by any team, the PR is not made to be backwards compatible with the existing cursor implementation.

- The outbox processor is now instantiated once instead of on every event consumption.
Before:
```
class Processor
  def initialize(event)
    @event = event
  end

  def call
  end
end
```

After:
```
class Processor
  def call(event)
  end
end
```

- Added SIGTERM event handling and ensured event capture is only enabled when the consumer is started.
- Renamed some unused internal variables that will be used for future outbox scale out feature.