### PR TITLE
raise error on missing consumer config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.4.2 - 2024-04-30
+### Changed
+- Raise error on missing consumer config
+
 ## 1.4.1 - 2024-04-28
 ### Fixed
 - Fix Sidebar scroll

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventsimple (1.4.1)
+    eventsimple (1.4.2)
       dry-struct (~> 1.6)
       dry-types (~> 1.7)
       pg (~> 1.4)

--- a/lib/eventsimple/outbox/consumer.rb
+++ b/lib/eventsimple/outbox/consumer.rb
@@ -12,11 +12,11 @@ module Eventsimple
           class_attribute :_processor_klass
           class_attribute :_processor
           class_attribute :stop_consumer, default: false
-          class_attribute :_identifier, default: name.to_s
+          class_attribute :_identifier
         end
       end
 
-      def identifier(name = nil)
+      def identifier(name)
         self._identifier = name
       end
 
@@ -46,6 +46,12 @@ module Eventsimple
       end
 
       def run_consumer(group_number:)
+        raise 'Eventsimple: No event class defined' unless _event_klass
+        raise 'Eventsimple: No processor defined' unless _processor
+        raise 'Eventsimple: No identifier defined' unless _identifier
+
+        Rails.logger.info("Starting consumer for #{_identifier}, processing #{_event_klass} events with group number #{group_number}")
+
         cursor = Outbox::Cursor.fetch(_identifier, group_number: group_number)
 
         until stop_consumer

--- a/lib/eventsimple/version.rb
+++ b/lib/eventsimple/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Eventsimple
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end

--- a/spec/dummy/spec/components/user_component/consumer_spec.rb
+++ b/spec/dummy/spec/components/user_component/consumer_spec.rb
@@ -23,6 +23,26 @@ RSpec.describe UserComponent::Consumer do
     expect(described_class._processor_klass).to eq(UserComponent::EventProcessor)
   end
 
+  context 'with invalid configuration' do
+    it 'raises an error when no event class is defined' do
+      described_class._event_klass = nil
+      expect { run_consumer }.to raise_error(RuntimeError, 'Eventsimple: No event class defined')
+      described_class._event_klass = UserEvent
+    end
+
+    it 'raises an error when no processor is defined' do
+      described_class._processor = nil
+      expect { run_consumer }.to raise_error(RuntimeError, 'Eventsimple: No processor defined')
+      described_class._processor = UserComponent::EventProcessor.new
+    end
+
+    it 'raises an error when no identifier is defined' do
+      described_class._identifier = nil
+      expect { run_consumer }.to raise_error(RuntimeError, 'Eventsimple: No identifier defined')
+      described_class._identifier = 'UserComponent::Consumer'
+    end
+  end
+
   describe '.run_consumer' do
     it 'records the last processed event position' do
       event = create(:user_event)


### PR DESCRIPTION
Enforce all configure options are passed in when instantiating a consumer