### PR TITLE
Consumer concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.5.0 - 2024-05-07
+### Changed
+- The outbox consumer processes event batches concurrently
+- Removes unused group_number/group_size config
+
 ## 1.4.3 - 2024-05-06
 ### Changed
 - The order of execution for synchronous reactors is now guaranteed to be the order in which they were registered.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    eventsimple (1.4.3)
+    eventsimple (1.5.0)
+      concurrent-ruby (>= 1.2.3)
       dry-struct (~> 1.6)
       dry-types (~> 1.7)
       pg (~> 1.4)

--- a/README.md
+++ b/README.md
@@ -276,9 +276,9 @@ end
 
 ## Configuring an outbox consumer
 
-For many use cases, async reactors are sufficient to handle workflows like making an API call or publishing to a message broker. However as reactors use ActiveJob, order is not guaranteed. For use cases requiring order, eventsimple provides an ordered outbox implementation.
+For many use cases, async reactors are sufficient to handle workflows like making an API call or publishing to a message broker. However as reactors use ActiveJob, order is not guaranteed. For use cases requiring order, eventsimple provides an simple ordered outbox implementation.
 
-**Caveat**: The current implementation leverages a single advisory lock to guarantee write order. This will impact write throughput on the model. On a db.rg6.large Aurora instance for example, write throughput is limited to ~300 events per second.
+The current implementation leverages a single advisory lock to guarantee write order. This will impact write throughput on the model. On a db.rg6.large Aurora instance for example, write throughput to the table is ~300 events per second.
 
 For an explaination of why an advisory lock is required:
 https://github.com/pawelpacana/account-basics
@@ -292,7 +292,6 @@ Generate migration to setup the outbox cursor table. This table is used to track
 ```
 
 Create a consummer and processor class for the outbox.
-Note: The presence of the consumer class moves all writes to the respective events table to be written using an advisory lock.
 
 ```ruby
 require 'eventsimple/outbox/consumer'
@@ -304,6 +303,7 @@ module UserComponent
     identitfier 'UserComponent::Consumer'
     consumes_event UserEvent
     processor EventProcessor
+    concurrency 5 # default is 5
   end
 end
 ```

--- a/eventsimple.gemspec
+++ b/eventsimple.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rails', '~> 7.0'
   spec.add_runtime_dependency 'retriable', '~> 3.1'
   spec.add_runtime_dependency 'with_advisory_lock', '>= 5.1'
+  spec.add_runtime_dependency 'concurrent-ruby', '>= 1.2.3'
 
   spec.add_development_dependency 'bundle-audit'
   spec.add_development_dependency 'fuubar'

--- a/lib/eventsimple/engine.rb
+++ b/lib/eventsimple/engine.rb
@@ -12,6 +12,7 @@ module Eventsimple
 
     config.after_initialize do
       require 'eventsimple/reactor'
+      require 'eventsimple/outbox/models/cursor'
 
       verify_dispatchers!
 

--- a/lib/eventsimple/event.rb
+++ b/lib/eventsimple/event.rb
@@ -15,7 +15,6 @@ module Eventsimple
       self._aggregate_id = aggregate_id
 
       class_attribute :_outbox_enabled
-      class_attribute :_consumer_group_size
 
       class_attribute :_on_invalid_transition
       self._on_invalid_transition = ->(error) { raise error }

--- a/lib/eventsimple/generators/outbox/templates/create_outbox_cursor.erb
+++ b/lib/eventsimple/generators/outbox/templates/create_outbox_cursor.erb
@@ -4,10 +4,9 @@ class CreateEventsimpleOutboxCursor < ActiveRecord::Migration<%= migration_versi
   def change
     create_table :eventsimple_outbox_cursors do |t|
       t.string :event_klass, null: false
-      t.integer :group_number, null: false
       t.bigint :cursor, null: false
 
-      t.index [:event_klass, :group_number], unique: true
+      t.index [:event_klass], unique: true
     end
   end
 end

--- a/lib/eventsimple/outbox/models/cursor.rb
+++ b/lib/eventsimple/outbox/models/cursor.rb
@@ -6,14 +6,14 @@ module Eventsimple
       self.table_name = 'eventsimple_outbox_cursors'
 
       def self.fetch(identifier)
-        existing = find_by(identifier: identifier.to_s)
+        existing = find_by(identifier: identifier)
         existing ? existing.cursor : 0
       end
 
       def self.set(identifier, cursor)
         upsert(
           {
-            identifier: identifier.to_s,
+            identifier: identifier,
             cursor: cursor,
           },
           unique_by: [:identifier],

--- a/lib/eventsimple/outbox/models/cursor.rb
+++ b/lib/eventsimple/outbox/models/cursor.rb
@@ -5,19 +5,18 @@ module Eventsimple
     class Cursor < Eventsimple.configuration.parent_record_klass
       self.table_name = 'eventsimple_outbox_cursors'
 
-      def self.fetch(identifier, group_number: 0)
-        existing = find_by(identifier: identifier.to_s, group_number: group_number)
+      def self.fetch(identifier)
+        existing = find_by(identifier: identifier.to_s)
         existing ? existing.cursor : 0
       end
 
-      def self.set(identifier, cursor, group_number: 0)
+      def self.set(identifier, cursor)
         upsert(
           {
             identifier: identifier.to_s,
-            group_number: group_number,
             cursor: cursor,
           },
-          unique_by: [:identifier, :group_number],
+          unique_by: [:identifier],
         )
       end
     end

--- a/lib/eventsimple/version.rb
+++ b/lib/eventsimple/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Eventsimple
-  VERSION = '1.4.3'
+  VERSION = '1.5.0'
 end

--- a/spec/dummy/db/migrate/20240419175459_create_eventsimple_outbox_cursor.rb
+++ b/spec/dummy/db/migrate/20240419175459_create_eventsimple_outbox_cursor.rb
@@ -4,11 +4,9 @@ class CreateEventsimpleOutboxCursor < ActiveRecord::Migration[7.1]
   def change
     create_table :eventsimple_outbox_cursors do |t|
       t.string :identifier, null: false
-      t.integer :group_number, null: false
       t.bigint :cursor, null: false
 
-      t.index [:identifier, :group_number], unique: true,
-        name: 'index_eventsimple_outbox_cursors_event_klass_group_number'
+      t.index [:identifier], unique: true
     end
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -16,9 +16,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_19_175459) do
 
   create_table "eventsimple_outbox_cursors", force: :cascade do |t|
     t.string "identifier", null: false
-    t.integer "group_number", null: false
     t.bigint "cursor", null: false
-    t.index ["identifier", "group_number"], name: "idx_on_identifier_group_number_1aba2c6d46", unique: true
+    t.index ["identifier"], name: "index_eventsimple_outbox_cursors_on_identifier", unique: true
   end
 
   create_table "user_events", force: :cascade do |t|

--- a/spec/dummy/spec/components/user_component/consumer_spec.rb
+++ b/spec/dummy/spec/components/user_component/consumer_spec.rb
@@ -5,11 +5,23 @@ RSpec.describe UserComponent::Consumer do
     allow(described_class).to receive(:sleep) do
       described_class.stop_consumer = true
     end
+    allow(described_class._processor_pool[0]).to receive(:call)
+    allow(described_class._processor_pool[1]).to receive(:call)
+    allow(described_class._processor_pool[2]).to receive(:call)
+    allow(described_class._processor_pool[3]).to receive(:call)
+    allow(described_class._processor_pool[4]).to receive(:call)
   end
 
   after do
     described_class.stop_consumer = false
   end
+
+  let!(:event1) { create(:user_event, user: create(:user, canonical_id: '7a5dc301-c982-4871-bd25-a5eadc97113a')) }
+  let!(:event2) { create(:user_event, user: create(:user, canonical_id: '0e0ce944-8299-4c55-b58e-c48a766b44c4')) }
+  let!(:event3) { create(:user_event, user: create(:user, canonical_id: '9abde676-8a1e-473d-a095-9651ac177b37')) }
+  let!(:event4) { create(:user_event, user: create(:user, canonical_id: '65b0303a-5239-4212-9127-a9dc01658e38')) }
+  let!(:event5) { create(:user_event, user: create(:user, canonical_id: 'f77a5726-f10e-45c6-92a1-62073f1720d1')) }
+  let!(:event5_2) { create(:user_event, user: create(:user, canonical_id: '5cd4914b-e03c-4c20-aaf0-a2b9769fd514')) }
 
   it 'has an identifier' do
     expect(described_class._identifier).to eq('UserComponent::Consumer')
@@ -30,10 +42,10 @@ RSpec.describe UserComponent::Consumer do
       described_class._event_klass = UserEvent
     end
 
-    it 'raises an error when no processor is defined' do
-      described_class._processor = nil
+    it 'raises an error when no processor class is defined' do
+      described_class._processor_klass = nil
       expect { run_consumer }.to raise_error(RuntimeError, 'Eventsimple: No processor defined')
-      described_class._processor = UserComponent::EventProcessor.new
+      described_class._processor_klass = UserComponent::EventProcessor.new
     end
 
     it 'raises an error when no identifier is defined' do
@@ -44,54 +56,80 @@ RSpec.describe UserComponent::Consumer do
   end
 
   describe '.run_consumer' do
-    it 'records the last processed event position' do
-      event = create(:user_event)
-
+    it 'executes processors and records the last processed event position' do
       cursor = Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer')
       expect(cursor).to be(0)
 
-      expect(described_class._processor).to receive(:call).once
+      run_consumer
+
+      expect(described_class._processor_pool[0]).to have_received(:call).once
+      expect(described_class._processor_pool[1]).to have_received(:call).once
+      expect(described_class._processor_pool[2]).to have_received(:call).once
+      expect(described_class._processor_pool[3]).to have_received(:call).once
+      expect(described_class._processor_pool[4]).to have_received(:call).twice
+
+      cursor = Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer')
+      expect(cursor).to eq(event5_2.id)
+    end
+
+    it 'updates the cursor position after each batch' do
+      allow(described_class).to receive(:sleep)
+      described_class._batch_size = 2
+
+      expect(Eventsimple::Outbox::Cursor).to receive(:set).with('UserComponent::Consumer', event2.id)
+      expect(Eventsimple::Outbox::Cursor).to receive(:set).with('UserComponent::Consumer', event4.id)
+      expect(Eventsimple::Outbox::Cursor).to receive(:set).with('UserComponent::Consumer', event5_2.id) do
+        described_class.stop_consumer = true
+      end
 
       run_consumer
 
-      cursor = Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer')
-      expect(cursor).to eq(event.id)
+      described_class._batch_size = 1000
     end
 
-    context 'when consumer is stopped inside batch' do
-      let(:user) { create(:user) }
-      let!(:events) { create_list(:user_event, 1100, user: user) }
+    context 'when consumer is stopped while inside batch' do
+      it 'does not change cursor position' do
+        allow(described_class._processor_pool[4]).to receive(:call) do |e|
+          expect(e.id).to be_in([event5.id, event5_2.id])
 
-      it 'breaks correctly and sets the cursor to the last processed event position' do
-        allow(described_class._processor).to receive(:call) do |e|
-          expect(e.id).to be_in(events[0..1].map(&:id))
-
-          # stop consumer after the second event in the batch is processed
-          if e.id == events[1].id
-            described_class.stop_consumer = true
-          end
+          described_class.stop_consumer = true if e.id == event5_2.id
         end
 
         run_consumer
 
-        expect(described_class._processor).to have_received(:call).exactly(2).times
-        expect(Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer')).to eq(events[1].id)
+        expect(Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer')).to eq(0)
+      end
+    end
+
+    context 'when any processor raises an exception' do
+      it 'does not change cursor position' do
+        allow(described_class._processor_pool[4]).to receive(:call) do |e|
+          expect(e.id).to be_in([event5.id, event5_2.id])
+
+          raise 'unknown_error' if e.id == event5_2.id
+        end
+
+        expect { run_consumer }.to raise_error(RuntimeError, 'unknown_error')
+
+        expect(Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer')).to eq(0)
       end
     end
 
     context 'with an existing cursor' do
-      let!(:events) { create_list(:user_event, 5) }
-
       before do
-        Eventsimple::Outbox::Cursor.set('UserComponent::Consumer', events[2].id)
-        allow(described_class._processor).to receive(:call)
+        Eventsimple::Outbox::Cursor.set('UserComponent::Consumer', event2.id)
       end
 
       it 'starts after the last processed event position' do
         run_consumer
 
-        expect(described_class._processor).to have_received(:call).twice
-        expect(Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer')).to eq(events[4].id)
+        expect(described_class._processor_pool[0]).not_to have_received(:call)
+        expect(described_class._processor_pool[1]).not_to have_received(:call)
+        expect(described_class._processor_pool[2]).to have_received(:call).once
+        expect(described_class._processor_pool[3]).to have_received(:call).once
+        expect(described_class._processor_pool[4]).to have_received(:call).twice
+
+        expect(Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer')).to eq(event5_2.id)
       end
     end
   end

--- a/spec/dummy/spec/components/user_component/consumer_spec.rb
+++ b/spec/dummy/spec/components/user_component/consumer_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe UserComponent::Consumer do
-  subject(:run_consumer) { described_class.run_consumer(group_number: 0) }
+  subject(:run_consumer) { described_class.run_consumer }
 
   before do
     allow(described_class).to receive(:sleep) do
@@ -47,14 +47,14 @@ RSpec.describe UserComponent::Consumer do
     it 'records the last processed event position' do
       event = create(:user_event)
 
-      cursor = Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer', group_number: 0)
+      cursor = Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer')
       expect(cursor).to be(0)
 
       expect(described_class._processor).to receive(:call).once
 
       run_consumer
 
-      cursor = Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer', group_number: 0)
+      cursor = Eventsimple::Outbox::Cursor.fetch('UserComponent::Consumer')
       expect(cursor).to eq(event.id)
     end
 

--- a/spec/dummy/spec/factories/user_event.rb
+++ b/spec/dummy/spec/factories/user_event.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :user_event do
     user
-    type { 'UserComponent::Events::Created' }
+    type { 'Created' }
     data {
       {
         canonical_id: SecureRandom.uuid,


### PR DESCRIPTION
Add concurrent processing to outbox consumer.
The consumer will process batches concurrently, while maintaining order based on the aggregate_id.

Removes group_number/group_size configuration, that was initially added for a different approach to concurrency.