### PR TITLE
feat: `yield self` in `enable_writes!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.5.3 - 2024-09-09
+### Changed
+- Pass self to `enable_writes!` block
+
 ## 1.5.2 - 2024-05-22
 ### Changed
 - Add created_at index in events migration generation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventsimple (1.5.2)
+    eventsimple (1.5.3)
       concurrent-ruby (>= 1.2.3)
       dry-struct (~> 1.6)
       dry-types (~> 1.7)
@@ -109,7 +109,7 @@ GEM
     dry-core (1.0.1)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
-    dry-inflector (1.0.0)
+    dry-inflector (1.1.0)
     dry-logic (1.5.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
@@ -184,7 +184,7 @@ GEM
     minitest (5.22.2)
     mutex_m (0.2.0)
     nenv (0.3.0)
-    net-imap (0.4.11)
+    net-imap (0.4.16)
       date
       net-protocol
     net-pop (0.1.2)
@@ -207,7 +207,7 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
-    pg (1.5.6)
+    pg (1.5.8)
     polyglot (0.3.5)
     pry (0.14.2)
       coderay (~> 1.1)

--- a/lib/eventsimple/entity.rb
+++ b/lib/eventsimple/entity.rb
@@ -39,7 +39,7 @@ module Eventsimple
         @readonly = false
 
         if block
-          yield
+          yield self
           @readonly = true if was_readonly
         end
       end

--- a/lib/eventsimple/version.rb
+++ b/lib/eventsimple/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Eventsimple
-  VERSION = '1.5.2'
+  VERSION = '1.5.3'
 end

--- a/spec/lib/eventsimple/entity_spec.rb
+++ b/spec/lib/eventsimple/entity_spec.rb
@@ -56,6 +56,12 @@ module Eventsimple
       end
 
       context 'when enabled with a block' do
+        it 'passes self into the block' do
+          user.enable_writes! do |entity|
+            expect(entity).to eq(user)
+          end
+        end
+
         context 'when the entity was readonly before' do
           it 'restores readonly status after the block' do
             user.readonly!


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

Common pattern that simplifies one-liner syntax like `User.find(123).enable_writes! { |user| user.destroy! }`

#### What changed <!-- Summary of changes when modifying hundreds of lines -->

`yield self` when block is passed to `#enable_writes!`