### PR TITLE
inheritance column setter needs to be a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.5.6 - 2025-01-02
+### Changed
+- inheritance column setter needs to be a string
+
 ## 1.5.5 - 2024-12-23
 ### Changed
 - Validate value and type of `aggregate_id` between Event and Entity

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventsimple (1.5.5)
+    eventsimple (1.5.6)
       concurrent-ruby (>= 1.2.3)
       dry-struct (~> 1.6)
       dry-types (~> 1.7)

--- a/lib/eventsimple/event.rb
+++ b/lib/eventsimple/event.rb
@@ -31,7 +31,7 @@ module Eventsimple
       class_attribute :_on_invalid_transition
       self._on_invalid_transition = ->(error) { raise error }
 
-      self.inheritance_column = :type
+      self.inheritance_column = 'type'
       self.store_full_sti_class = false
 
       attribute :metadata, MetadataType.new

--- a/lib/eventsimple/version.rb
+++ b/lib/eventsimple/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Eventsimple
-  VERSION = '1.5.5'
+  VERSION = '1.5.6'
 end


### PR DESCRIPTION
The value of inheritance_column is expected to be a string, this was not enforced in rails versions < 8.