### PR TITLE
docs(README): remove hijacked repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,6 @@ For many use cases, async reactors are sufficient to handle workflows like makin
 
 The current implementation leverages a single advisory lock to guarantee write order. This will impact write throughput on the model. On a db.rg6.large Aurora instance for example, write throughput to the table is ~300 events per second.
 
-For an explaination of why an advisory lock is required:
-https://github.com/pawelpacana/account-basics
-
 ### Setup an ordered outbox
 
 Generate migration to setup the outbox cursor table. This table is used to track cursor positions.


### PR DESCRIPTION
### Why
A link to a repo from a deleted Github account was vulnerable to account squatting/takeover, leading to potential phishing vector. 

### What changed
Removed the hijacked link.


A thank you to @nvk0x for helping identify this potential security vulnerability through our [HackerOne bug bounty program](https://hackerone.com/wealthsimple).

@wealthsimple/banking @wealthsimple/appsec-posture 