### PR TITLE
fix: catalog-info.yaml [skip ci]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,3 +9,4 @@ metadata:
 spec:
   type: library
   lifecycle: production
+  owner: engineering


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

The CODEOWNERS file was removed which means the Backstage catalog-info.yaml file won't resolve an owner anymore.

#### What changed <!-- Summary of changes when modifying hundreds of lines -->

Add an explicit `spec.owner` to `engineering`

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
